### PR TITLE
Fixed NoSuchMethodError for Minecraft 1.21.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     runtimeOnly(project(":playerdata_1_18_2", configuration = "reobf"))
     runtimeOnly(project(":playerdata_1_20_2", configuration = "reobf"))
     runtimeOnly(project(":playerdata_1_21_4", configuration = "reobf"))
+    runtimeOnly(project(":playerdata_1_21_5", configuration = "reobf"))
     runtimeOnly(project(":playerdata_1_21_10"))
 
     // hk2 annotations

--- a/playerdata/src/main/java/org/mvplugins/multiverse/inventoriesimporter/playerdata/PlayerDataProvider.java
+++ b/playerdata/src/main/java/org/mvplugins/multiverse/inventoriesimporter/playerdata/PlayerDataProvider.java
@@ -4,7 +4,6 @@ import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 import org.mvplugins.multiverse.external.vavr.collection.HashMap;
 import org.mvplugins.multiverse.external.vavr.collection.Map;
-import org.mvplugins.multiverse.inventories.utils.InvLogging;
 
 public interface PlayerDataProvider {
     PlayerDataImporter getImporter();
@@ -20,7 +19,8 @@ public interface PlayerDataProvider {
                 MinecraftVersion.rangeAtMost("1.19.3"), "1_18_2",
                 MinecraftVersion.range("1.19.4", "1.20.2"), "1_20_2",
                 MinecraftVersion.range("1.20.3", "1.21.4"), "1_21_4",
-                MinecraftVersion.rangeAtLeast("1.21.5"), "1_21_10"
+                MinecraftVersion.range("1.21.5", "1.21.5"), "1_21_5",
+                MinecraftVersion.rangeAtLeast("1.21.6"), "1_21_10"
         );
 
         static {

--- a/playerdata_1_21_5/build.gradle.kts
+++ b/playerdata_1_21_5/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    `my-conventions`
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.19"
+}
+
+dependencies {
+    implementation(project(":playerdata"))
+
+    paperweight.paperDevBundle("1.21.5-R0.1-SNAPSHOT")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    // Override release for newer MC
+    options.release = 21
+}

--- a/playerdata_1_21_5/src/main/java/org/mvplugins/multiverse/inventoriesimporter/playerdata_1_21_5/PlayerDataImporter_1_21_5.java
+++ b/playerdata_1_21_5/src/main/java/org/mvplugins/multiverse/inventoriesimporter/playerdata_1_21_5/PlayerDataImporter_1_21_5.java
@@ -1,0 +1,133 @@
+package org.mvplugins.multiverse.inventoriesimporter.playerdata_1_21_5;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.util.datafix.DataFixTypes;
+import net.minecraft.util.datafix.DataFixers;
+import org.bukkit.inventory.ItemStack;
+import org.mvplugins.multiverse.external.vavr.control.Try;
+import org.mvplugins.multiverse.inventories.profile.data.ProfileData;
+import org.mvplugins.multiverse.inventories.profile.data.ProfileDataSnapshot;
+import org.mvplugins.multiverse.inventories.share.Sharables;
+import org.mvplugins.multiverse.inventories.util.PlayerStats;
+import org.mvplugins.multiverse.inventories.utils.InvLogging;
+import org.mvplugins.multiverse.inventoriesimporter.playerdata.PlayerDataImporter;
+
+import javax.annotation.Nullable;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.util.Optional;
+
+public class PlayerDataImporter_1_21_5 implements PlayerDataImporter {
+
+    public Try<ProfileData> readPlayerDataFromFile(File playerDataFile) {
+        return loadAndUpgradePlayerData(playerDataFile)
+                .flatMapTry(this::convertToProfileData)
+                .onFailure(throwable -> InvLogging.warning("Failed to load player data from file %s: %s",
+                        playerDataFile.getName(), throwable.getMessage()));
+    }
+
+    private Try<CompoundTag> loadAndUpgradePlayerData(File playerDataFile) {
+        return Try.of(() -> NbtIo.readCompressed(playerDataFile.toPath(), NbtAccounter.unlimitedHeap()))
+                .mapTry(compoundTag -> {
+                    int dataVersion = compoundTag.getIntOr("DataVersion", -1);
+                    CompoundTag upgradedTag = DataFixTypes.PLAYER.updateToCurrentVersion(DataFixers.getDataFixer(), compoundTag, dataVersion);
+                    upgradedTag.putInt("DataVersion", SharedConstants.getCurrentVersion().getDataVersion().getVersion());
+                    InvLogging.finest("Upgraded player data from version %d to %d", dataVersion, upgradedTag.getIntOr("DataVersion", -1));
+                    return upgradedTag;
+                });
+    }
+
+    private Try<ProfileData> convertToProfileData(CompoundTag playerData) {
+        return Try.of(() -> {
+            int dataVersion = playerData.getIntOr("DataVersion", -1);
+            InvLogging.finest("Data version: %s", dataVersion);
+            CompoundTag equipment = playerData.getCompoundOrEmpty("equipment");
+            ListTag inventory = playerData.getListOrEmpty("Inventory");
+
+            ProfileData profileData = new ProfileDataSnapshot();
+
+            profileData.set(Sharables.ARMOR, new ItemStack[]{
+                    extractItemStack(equipment.getCompoundOrEmpty("feet"), dataVersion),
+                    extractItemStack(equipment.getCompoundOrEmpty("legs"), dataVersion),
+                    extractItemStack(equipment.getCompoundOrEmpty("chest"), dataVersion),
+                    extractItemStack(equipment.getCompoundOrEmpty("head"), dataVersion)
+            });
+            // ADVANCEMENTS
+            // BED_SPAWN
+            profileData.set(Sharables.ENDER_CHEST, extractInventory(
+                    playerData.getListOrEmpty("EnderItems"),
+                    dataVersion,
+                    PlayerStats.ENDER_CHEST_SIZE
+            ));
+            profileData.set(Sharables.EXHAUSTION, playerData.getFloatOr("foodExhaustionLevel", PlayerStats.EXHAUSTION));
+            profileData.set(Sharables.EXPERIENCE, playerData.getFloatOr("XpP", PlayerStats.EXPERIENCE));
+            profileData.set(Sharables.FALL_DISTANCE, (float) playerData.getDoubleOr("fall_distance", PlayerStats.FALL_DISTANCE));
+            profileData.set(Sharables.FIRE_TICKS, (int) playerData.getShortOr("Fire", (short) PlayerStats.FIRE_TICKS));
+            profileData.set(Sharables.FOOD_LEVEL, playerData.getIntOr("foodLevel", PlayerStats.FOOD_LEVEL));
+            // GAME_STATISTICS
+            profileData.set(Sharables.HEALTH, (double) playerData.getFloatOr("Health", (float) PlayerStats.HEALTH));
+            profileData.set(Sharables.INVENTORY, extractInventory(
+                    inventory,
+                    dataVersion,
+                    PlayerStats.INVENTORY_SIZE
+            ));
+            // LAST_LOCATION
+            profileData.set(Sharables.LEVEL, playerData.getIntOr("XpLevel", PlayerStats.LEVEL));
+            // MAXIMUM_AIR
+            // MAX_HEALTH
+            profileData.set(Sharables.OFF_HAND, extractItemStack(equipment.getCompoundOrEmpty("offhand"), dataVersion));
+            // POTIONS
+            // RECIPES
+            profileData.set(Sharables.REMAINING_AIR, (int) playerData.getShortOr("Air", (short) PlayerStats.REMAINING_AIR));
+            profileData.set(Sharables.SATURATION, playerData.getFloatOr("foodSaturationLevel", PlayerStats.SATURATION));
+            profileData.set(Sharables.TOTAL_EXPERIENCE, playerData.getIntOr("XpTotal", PlayerStats.TOTAL_EXPERIENCE));
+
+            return profileData;
+        });
+    }
+
+    private ItemStack extractItemStackFromSlot(@Nullable ListTag inventoryList, int dataVersion, int targetSlot) {
+        return Optional.ofNullable(inventoryList)
+                .flatMap(list -> list.stream()
+                        .filter(tagData -> tagData instanceof CompoundTag)
+                        .map(tagData -> (CompoundTag) tagData)
+                        .filter(invData -> invData.getByteOr("Slot", (byte) -1) == targetSlot)
+                        .findFirst()
+                        .map(itemData -> extractItemStack(itemData, dataVersion)))
+                .orElse(null);
+    }
+
+    private ItemStack[] extractInventory(@Nullable ListTag inventoryList, int dataVersion, int inventorySize) {
+        return Optional.ofNullable(inventoryList)
+                .map(list -> list.stream()
+                        .filter(tagData -> tagData instanceof CompoundTag)
+                        .map(tagData -> (CompoundTag) tagData)
+                        .filter(invData -> {
+                            int slot = invData.getByteOr("Slot", (byte) -1);
+                            return slot >= 0 && slot < inventorySize;
+                        })
+                        .map(itemData -> extractItemStack(itemData, dataVersion))
+                        .toArray(size -> new ItemStack[inventorySize]))
+                .orElseGet(() -> new ItemStack[inventorySize]);
+    }
+
+    private @Nullable ItemStack extractItemStack(@Nullable CompoundTag itemStackData, int dataVersion) {
+        if (itemStackData == null) {
+            return null;
+        }
+        CompoundTag itemStackDataCopy = itemStackData.copy();
+        // itemStackDataCopy.remove("Slot");
+        itemStackDataCopy.putInt("DataVersion", dataVersion);
+        return Try.of(() -> {
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            NbtIo.writeCompressed(itemStackDataCopy, byteArrayOutputStream);
+            byteArrayOutputStream.close();
+            return ItemStack.deserializeBytes(byteArrayOutputStream.toByteArray());
+        }).onFailure(throwable -> InvLogging.warning("Failed to deserialize item: %s", throwable.getMessage()))
+                .getOrNull();
+    }
+}

--- a/playerdata_1_21_5/src/main/java/org/mvplugins/multiverse/inventoriesimporter/playerdata_1_21_5/PlayerDataProvider_1_21_5.java
+++ b/playerdata_1_21_5/src/main/java/org/mvplugins/multiverse/inventoriesimporter/playerdata_1_21_5/PlayerDataProvider_1_21_5.java
@@ -1,0 +1,14 @@
+package org.mvplugins.multiverse.inventoriesimporter.playerdata_1_21_5;
+
+import org.mvplugins.multiverse.inventoriesimporter.playerdata.PlayerDataImporter;
+import org.mvplugins.multiverse.inventoriesimporter.playerdata.PlayerDataProvider;
+
+public class PlayerDataProvider_1_21_5 implements PlayerDataProvider {
+
+    private final PlayerDataImporter importer = new PlayerDataImporter_1_21_5();
+
+    @Override
+    public PlayerDataImporter getImporter() {
+        return importer;
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ rootProject.name = "Multiverse-InventoriesImporter"
 
 include("playerdata")
 include("playerdata_1_21_10")
+include("playerdata_1_21_5")
 include("playerdata_1_21_4")
 include("playerdata_1_20_2")
 include("playerdata_1_18_2")


### PR DESCRIPTION
This fixes getting the exception NoSuchMethodError when running on a 1.21.5 server. The main section of the code is copied from the 1.21.10 implementation with only dataVersion().version() changed.

It has only been tested on a 1.21.5 paper server not any other versions (in case I messed up the version mappings)

I am unsure if I should have `configuration = "reobf"` on this version or not (Not sure what rebof is)

Fixes #1