### PR TITLE
Add PWI legacy v3 format support and bug fixes

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/inventoriesimporter/multiverseInventoriesImporter/migrate/perworldinventory/PwiImportHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventoriesimporter/multiverseInventoriesImporter/migrate/perworldinventory/PwiImportHelper.java
@@ -334,7 +334,7 @@ final class PwiImportHelper {
             mvPlayerProfile.set(Sharables.REMAINING_AIR, pwiPlayerProfile.getRemainingAir());
         }
         if (pwiSettings.getProperty(PlayerSettings.LOAD_SATURATION)) {
-            mvPlayerProfile.set(Sharables.REMAINING_AIR, pwiPlayerProfile.getRemainingAir());
+            mvPlayerProfile.set(Sharables.SATURATION, pwiPlayerProfile.getSaturation());
         }
         // if (pwiSettings.getProperty(PlayerSettings.LOAD_DISPLAY_NAME)) {
         //     mvPlayerProfile.set(Sharables, pwiPlayerProfile.getDisplayName());

--- a/src/main/java/org/mvplugins/multiverse/inventoriesimporter/multiverseInventoriesImporter/migrate/perworldinventory/PwiImportHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventoriesimporter/multiverseInventoriesImporter/migrate/perworldinventory/PwiImportHelper.java
@@ -15,6 +15,7 @@ import me.ebonjaeger.perworldinventory.serialization.PlayerSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -239,14 +240,18 @@ final class PwiImportHelper {
         try {
             JSONParser parser = new JSONParser(JSONParser.USE_INTEGER_STORAGE);
             JSONObject jsonObject = (JSONObject) parser.parse(new FileInputStream(pwiPlayerDataFile));
+
             if (jsonObject.containsKey("==")) {
                 pwiPlayerProfile = (me.ebonjaeger.perworldinventory.data.PlayerProfile) SerializationHelper.deserialize(jsonObject, true);
             } else {
                 // Use legacy serialization that doesn't use ConfigurationSerializable
+                String playerName = Objects.requireNonNullElse(offlinePlayer.getName(), offlinePlayer.getUniqueId().toString());
+                // data-format v3 used getContents() which includes armor (36-39) and
+                // off-hand (40) in the main inventory array. Expect 41 slots.
                 pwiPlayerProfile = PlayerSerializer.INSTANCE.deserialize(
                         jsonObject,
-                        Objects.requireNonNull(offlinePlayer.getName()),
-                        PlayerStats.INVENTORY_SIZE,
+                        playerName,
+                        41,
                         PlayerStats.ENDER_CHEST_SIZE);
             }
         } catch (Exception e) {
@@ -291,7 +296,16 @@ final class PwiImportHelper {
         // Shares that are not available are commented out.
         if (pwiSettings.getProperty(PlayerSettings.LOAD_INVENTORY)) {
             mvPlayerProfile.set(Sharables.ARMOR, pwiPlayerProfile.getArmor());
-            mvPlayerProfile.set(Sharables.INVENTORY, pwiPlayerProfile.getInventory());
+
+            ItemStack[] fullInv = pwiPlayerProfile.getInventory();
+            if (fullInv.length > PlayerStats.INVENTORY_SIZE) {
+                // data-format v3 uses 41 slots. Slot 40 is the off-hand item.
+                ItemStack offHand = fullInv[40];
+                mvPlayerProfile.set(Sharables.OFF_HAND, offHand);
+                mvPlayerProfile.set(Sharables.INVENTORY, Arrays.copyOf(fullInv, PlayerStats.INVENTORY_SIZE));
+            } else {
+                mvPlayerProfile.set(Sharables.INVENTORY, fullInv);
+            }
         }
         if (pwiSettings.getProperty(PlayerSettings.USE_ECONOMY)) {
             mvPlayerProfile.set(Sharables.ECONOMY, pwiPlayerProfile.getBalance());


### PR DESCRIPTION
## Background

PerWorldInventory commit d5f0a55 (May 2018) changed the save path (v3 at the time) from getStorageContents() (36 slots) to getContents() (41 slots). This includes armor at 36–39 and off-hand at 40). This means v3 may have 36 or 41 slots before or after that commit.

Verified on my own server with 100 v3 and v4 inventories.

## Changes

### Fix inventory truncated to 36 slots

Pass 41 instead of PlayerStats.INVENTORY_SIZE to PlayerSerializer.deserialize for reading data-format v3 files with the full `getContents()` array.

### Fix off hand item never migrated

If there are 41 slots, split the returned array and extract index 40 as the off-hand item. Copy the first 36 to inventory regardless.

### Fix saturation mapped to wrong sharable

### Fix null player name crash

Objects.requireNonNull skips the user but a UUID works fine as a fallback.